### PR TITLE
AI generated: Add dat.gui with persistent settings and simulation reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "sensors",
       "version": "1.0.0",
       "dependencies": {
+        "@types/dat.gui": "^0.7.13",
         "@types/lodash": "^4.14.202",
+        "dat.gui": "^0.7.9",
         "prettier": "^3.6.2",
         "source-map-loader": "^0.2.4",
         "stats.js": "^0.17.0",
@@ -1096,6 +1098,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/dat.gui": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.13.tgz",
+      "integrity": "sha512-LmG4Pr0mbsB/1WVttf8xaHx45BvSBDGY5D9+0/9AZCbI4vvOguwBHZdKyJMxt5Yst8+icRSHKmr7ClV2u5ZtDA==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
@@ -1878,6 +1886,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dat.gui": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
+      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/debug": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "author": "https://github.com/mterczynski",
   "dependencies": {
+    "@types/dat.gui": "^0.7.13",
     "@types/lodash": "^4.14.202",
+    "dat.gui": "^0.7.9",
     "prettier": "^3.6.2",
     "source-map-loader": "^0.2.4",
     "stats.js": "^0.17.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -151,4 +151,35 @@ export class App {
     document.getElementById("aliveCounter")!.innerHTML =
       `Alive: ${aliveBotCount}/${settings.simulation.populationSize}`;
   }
+
+  resetSimulation() {
+    // Reset generation counter
+    this.generationIndex = 1;
+    document.getElementById("generationIndex")!.innerHTML = "Generation: 1";
+
+    // Create new bots with fresh neural networks
+    this.bots = new Array(settings.simulation.populationSize)
+      .fill(null)
+      .map(() => {
+        const startingBotPosition = _.sample(
+          settings.simulation.activeLevel.startingBotPositions,
+        )!;
+
+        const bot = new Bot(
+          startingBotPosition.x * settings.display.tileSize,
+          startingBotPosition.y * settings.display.tileSize,
+          this.levelData.tiles,
+        );
+
+        bot.setRotation(startingBotPosition.direction);
+
+        return bot;
+      });
+
+    // Update alive counter
+    this.updateAliveCounter(this.bots.length);
+
+    // Reset frame time to avoid time jump
+    this.previousFrameTime = Date.now();
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,10 @@
 import { App } from "./app";
+import { SettingsGUI } from "./settings-gui";
 
 const app = new App();
 app.init();
+
+// Initialize settings GUI with callback to reset simulation on settings change
+new SettingsGUI(() => {
+  app.resetSimulation();
+});

--- a/src/settings-gui.ts
+++ b/src/settings-gui.ts
@@ -48,7 +48,7 @@ export class SettingsGUI {
   private setupGUI() {
     // Simulation folder
     const simulationFolder = this.gui.addFolder("Simulation");
-    
+
     simulationFolder
       .add(settings.simulation, "sensorsPerBotCount", 3, 50, 1)
       .name("Sensors per Bot")
@@ -135,7 +135,10 @@ export class SettingsGUI {
       .add(settings.display.colors.sensorLine, "alphaAffectedByWeight")
       .name("Alpha by Weight")
       .onChange((value) => {
-        this.saveToLocalStorage("display.colors.sensorLine.alphaAffectedByWeight", value);
+        this.saveToLocalStorage(
+          "display.colors.sensorLine.alphaAffectedByWeight",
+          value,
+        );
       });
 
     // Reset button
@@ -146,7 +149,7 @@ export class SettingsGUI {
             this.resetSettings();
           },
         },
-        "resetSettings"
+        "resetSettings",
       )
       .name("Reset All Settings");
   }

--- a/src/settings-gui.ts
+++ b/src/settings-gui.ts
@@ -86,7 +86,7 @@ export class SettingsGUI {
       .name("Mutation Chance")
       .onChange((value) => {
         this.saveToLocalStorage("simulation.mutationChance", value);
-        this.onSettingsChange();
+        // Don't reset simulation - affects future generations only
       });
 
     simulationFolder
@@ -94,7 +94,7 @@ export class SettingsGUI {
       .name("Max Mutation Change")
       .onChange((value) => {
         this.saveToLocalStorage("simulation.maxMutationChange", value);
-        this.onSettingsChange();
+        // Don't reset simulation - affects future generations only
       });
 
     simulationFolder
@@ -102,7 +102,7 @@ export class SettingsGUI {
       .name("Anomalies Chance")
       .onChange((value) => {
         this.saveToLocalStorage("simulation.anomaliesChance", value);
-        this.onSettingsChange();
+        // Don't reset simulation - affects future generations only
       });
 
     simulationFolder.open();

--- a/src/settings-gui.ts
+++ b/src/settings-gui.ts
@@ -1,0 +1,168 @@
+import * as dat from "dat.gui";
+import { settings } from "./settings";
+
+const STORAGE_PREFIX = "mter_sensors_ai_";
+
+interface SettingsChangeCallback {
+  (): void;
+}
+
+export class SettingsGUI {
+  private gui: dat.GUI;
+  private onSettingsChange: SettingsChangeCallback;
+
+  constructor(onSettingsChange: SettingsChangeCallback) {
+    this.onSettingsChange = onSettingsChange;
+    this.gui = new dat.GUI();
+    this.loadSettings();
+    this.setupGUI();
+  }
+
+  private loadSettings() {
+    // Load settings from localStorage
+    const keys = Object.keys(localStorage);
+    keys
+      .filter((key) => key.startsWith(STORAGE_PREFIX))
+      .forEach((key) => {
+        const settingPath = key.replace(STORAGE_PREFIX, "");
+        const value = localStorage.getItem(key);
+        if (value !== null) {
+          this.setNestedValue(settings, settingPath, JSON.parse(value));
+        }
+      });
+  }
+
+  private setNestedValue(obj: any, path: string, value: any) {
+    const keys = path.split(".");
+    let current = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+      current = current[keys[i]];
+    }
+    current[keys[keys.length - 1]] = value;
+  }
+
+  private saveToLocalStorage(path: string, value: any) {
+    localStorage.setItem(STORAGE_PREFIX + path, JSON.stringify(value));
+  }
+
+  private setupGUI() {
+    // Simulation folder
+    const simulationFolder = this.gui.addFolder("Simulation");
+    
+    simulationFolder
+      .add(settings.simulation, "sensorsPerBotCount", 3, 50, 1)
+      .name("Sensors per Bot")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.sensorsPerBotCount", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder
+      .add(settings.simulation, "sensorAngle", 5, 180, 1)
+      .name("Sensor Angle")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.sensorAngle", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder
+      .add(settings.simulation, "speed", 0.1, 5, 0.1)
+      .name("Speed")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.speed", value);
+        // Don't reset simulation on speed change
+      });
+
+    simulationFolder
+      .add(settings.simulation, "populationSize", 10, 500, 10)
+      .name("Population Size")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.populationSize", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder
+      .add(settings.simulation, "mutationChance", 0, 1, 0.01)
+      .name("Mutation Chance")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.mutationChance", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder
+      .add(settings.simulation, "maxMutationChange", 0, 2, 0.05)
+      .name("Max Mutation Change")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.maxMutationChange", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder
+      .add(settings.simulation, "anomaliesChance", 0, 0.5, 0.01)
+      .name("Anomalies Chance")
+      .onChange((value) => {
+        this.saveToLocalStorage("simulation.anomaliesChance", value);
+        this.onSettingsChange();
+      });
+
+    simulationFolder.open();
+
+    // Display folder
+    const displayFolder = this.gui.addFolder("Display");
+
+    displayFolder
+      .add(settings.display, "drawAliveBotSensors")
+      .name("Draw Alive Bot Sensors")
+      .onChange((value) => {
+        this.saveToLocalStorage("display.drawAliveBotSensors", value);
+      });
+
+    displayFolder
+      .add(settings.display, "drawDeadBotSensors")
+      .name("Draw Dead Bot Sensors")
+      .onChange((value) => {
+        this.saveToLocalStorage("display.drawDeadBotSensors", value);
+      });
+
+    displayFolder
+      .add(settings.display, "maxBotsWithDrawnSensors", 0, 20, 1)
+      .name("Max Bots with Sensors")
+      .onChange((value) => {
+        this.saveToLocalStorage("display.maxBotsWithDrawnSensors", value);
+      });
+
+    displayFolder
+      .add(settings.display.colors.sensorLine, "alphaAffectedByWeight")
+      .name("Alpha by Weight")
+      .onChange((value) => {
+        this.saveToLocalStorage("display.colors.sensorLine.alphaAffectedByWeight", value);
+      });
+
+    // Reset button
+    this.gui
+      .add(
+        {
+          resetSettings: () => {
+            this.resetSettings();
+          },
+        },
+        "resetSettings"
+      )
+      .name("Reset All Settings");
+  }
+
+  private resetSettings() {
+    // Clear all localStorage items with our prefix
+    const keys = Object.keys(localStorage);
+    keys
+      .filter((key) => key.startsWith(STORAGE_PREFIX))
+      .forEach((key) => localStorage.removeItem(key));
+
+    // Reload the page to get default settings
+    window.location.reload();
+  }
+
+  destroy() {
+    this.gui.destroy();
+  }
+}


### PR DESCRIPTION
- Install dat.gui library with TypeScript types
- Create SettingsGUI class to manage settings interface
- Add localStorage persistence with 'mter_sensors_ai_' prefix
- Implement settings controls for simulation and display options
- Add resetSimulation() method to App class
- Reset simulation when settings change (except speed)
- Add "Reset All Settings" button to clear localStorage
- Wire up GUI initialization in main.ts

<img width="1506" height="713" alt="image" src="https://github.com/user-attachments/assets/8a55fddb-95f5-4c58-9d57-79f908ced083" />
